### PR TITLE
Fix compound

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ import io.izzel.taboolib.gradle.*
 plugins {
     `java-library`
     `maven-publish`
-    id("io.izzel.taboolib") version "2.0.20"
-    id("org.jetbrains.kotlin.jvm") version "1.9.22"
+    id("io.izzel.taboolib") version "2.0.22"
+    id("org.jetbrains.kotlin.jvm") version "1.8.22"
 }
 
 taboolib {
@@ -21,7 +21,7 @@ taboolib {
             BukkitNMSUtil,
         )
     }
-    version { taboolib = "6.2.0" }
+    version { taboolib = "6.2.1-f095116" }
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ taboolib {
             BukkitNMSUtil,
         )
     }
-    version { taboolib = "6.2.1-f095116" }
+    version { taboolib = "6.2.2" }
 }
 
 repositories {

--- a/src/main/kotlin/ink/ptms/fenestra/Workspace.kt
+++ b/src/main/kotlin/ink/ptms/fenestra/Workspace.kt
@@ -33,7 +33,7 @@ class Workspace(val player: CommandSender, val itemStack: ItemStack, val isReadO
     /**
      * 当前物品数据
      */
-    val compound = itemStack.getItemTag()
+    val compound = itemStack.getItemTag(onlyCustom = false)
 
     /**
      * 当前工作通道

--- a/src/main/kotlin/ink/ptms/fenestra/Workspace.kt
+++ b/src/main/kotlin/ink/ptms/fenestra/Workspace.kt
@@ -85,7 +85,7 @@ class Workspace(val player: CommandSender, val itemStack: ItemStack, val isReadO
      * 将缓存写入物品
      */
     fun saveWorkspace() {
-        compound.saveTo(itemStack)
+        compound.saveTo(itemStack, onlyCustom = false)
     }
 
     /**


### PR DESCRIPTION
修复了更新 TabooLib 后 Fenestra 在 1.20.5 及以上版本物品 NBT 数据读取问题。
三个月以前在推送给 TabooLib 的 [这个更新](https://github.com/TabooLib/taboolib/pull/452) 时已经使用此修改版的 Fenestra 在 Spigot 1.21 与 Paper 1.21.1 上通过测试。